### PR TITLE
Simplify Wercker release process

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -10,10 +10,7 @@ build:
                 gzip -c creep.bdf > creep.bdf.gz
 deploy:
     steps:
-        - script:
-            name: get version from the file comment
-            code: "export CREEP_VERSION=$(grep Version: creep.sfd | cut -d' ' -f 2)"
-        - github-create-release:
+        - motemen/github-create-release:
             token: $GITHUB_TOKEN
             tag: $CREEP_VERSION
         - github-upload-asset:

--- a/wercker.yml
+++ b/wercker.yml
@@ -12,7 +12,6 @@ deploy:
     steps:
         - motemen/github-create-release:
             token: $GITHUB_TOKEN
-            tag: $CREEP_VERSION
         - github-upload-asset:
             token: $GITHUB_TOKEN
             file: creep.dfont


### PR DESCRIPTION
Rather than modifying the version of the font file to do an automatic release, now it should just use the latest tagged commit, kind of like how you were doing before.